### PR TITLE
apx-search verb and bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,9 @@ var EcomIo = function () {
 
     'getProductbyName': function (term, callback) {
       var host = 'apx-search.e-com.plus'
-      var method = 'XPOST'
+      // proxy will pass XGET
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
+      var method = 'POST'
       var endpoint = '/items.json'
       // var body = {
       //   'query': {
@@ -134,7 +136,7 @@ var EcomIo = function () {
     }
 
   }
-}
+}()
 
 if (isNodeJs) {
   module.exports = EcomIo


### PR DESCRIPTION
1. We should send a POST request to apx-search.e-com.plus, proxy ignore it and will pass a XGET to backend.
2. EcomIo must be an object, we have to call the function automaticly, the function returns the object with interested methods.